### PR TITLE
✅ success: boj 15997 승부 예측

### DIFF
--- a/이지우/BJ_15997_승부예측.java
+++ b/이지우/BJ_15997_승부예측.java
@@ -1,0 +1,76 @@
+package A202206;
+
+import java.io.*;
+import java.util.*;
+
+public class BJ_15997_승부예측 {
+
+	static HashMap<String,Integer> nations = new HashMap<>();
+	static String[][] HA = new String[6][2];
+	static double[][] WLD = new double[6][3];
+	static double[] answer = new double[4];
+    // 백준 15997 - 승부 예측
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bufferedReader.readLine());
+        for(int i = 0; i < 4; i++) {
+        	nations.put(st.nextToken(), i);
+        }
+        for(int i = 0 ; i < 6; i++) {
+        	st = new StringTokenizer(bufferedReader.readLine());
+        	for(int j = 0; j < 2; j++) {
+        		HA[i][j] = st.nextToken();
+        	}
+        	for(int j = 0; j < 3; j++) {
+        		WLD[i][j] = Double.parseDouble(st.nextToken());
+        	}
+        }
+        dfs(1.0, 0, new int[4]);
+        
+        for(int i = 0; i < 4; i++) System.out.println(answer[i]);
+    }
+	private static void dfs(double percent, int i, int[] score) {
+		if(i == 6) {
+			int sorted[] = score.clone();
+			Arrays.sort(sorted);
+			int first = 0;
+			int second = 0;
+			for(int k = 0 ; k < 4; k++) {
+				if(sorted[3] == sorted[k]) {
+					first++;
+					continue;
+				}
+				if(sorted[2] == sorted[k])second++;
+			}
+			for(int k = 0 ; k < 4; k++) {
+				if(first >= 2 && score[k] == sorted[3]) {
+					answer[k] +=  percent * 2.0 / first;
+				}
+				if(first < 2 && score[k] == sorted[3]) {
+					answer[k] += percent;
+				}
+				if(second >= 1 && score[k] == sorted[2]) {
+					answer[k] += percent / second;
+				}
+			}
+			return;
+		}
+		int home = nations.get(HA[i][0]);
+		int away = nations.get(HA[i][1]);
+		for(int k = 0; k < 3; k++) {
+			if(WLD[i][k] == 0) continue;
+			int[] paramScore = score.clone();
+			if(k == 0) {
+				paramScore[home] += 3;
+			}else if(k == 1) {
+				paramScore[home] += 1;
+				paramScore[away] += 1;
+			}else {
+				paramScore[away] += 3;
+			}
+			dfs(percent * WLD[i][k], i+1, paramScore);
+		}
+		
+	}
+
+}


### PR DESCRIPTION
카카오 코딩페스티벌 본선 기출문제로 어렵고 재밌는 문제였습니다.
찾아보니까 66명중에 64명이 풀었답니다..ㅋㅋㅋㅋ

2가지를 고민해봐야하는데

1. 각경우의 수의 확률 구하기
  - 최대 경우의 수는 3^6인것을 알 수 있습니다. (승패무 비율 중 0이 있다면 줄어듬)
  - dfs로 풀어야 하며 각 dfs 리프노드단에서는 각 경우의 수에 따른 확률을 구해야합니다.
  - 추가로 넘어갈때마다 승/패에따른 점수를 셋팅해줘야합니다
 
이것이 해결되면 각 경우의 확률과 이 경우의 각팀의 점수가 나올것입니다. 
이거 바탕으로

2. 각 조별 2팀만 올라갈때 본선으로 진출할 확률
  - 점수가 같은경우가 없다면 문제가 안됩니다. 그냥 확률들을 더하면 됩니다.
  - 하지만 점수가 중복된다면 확률을 쪼개서 더해줘야합니다.

<html>
<body>
<!--StartFragment-->

14500KB | 128MS
-- | --


<!--EndFragment-->
</body>
</html>
