### PR TITLE
✅ success: boj 1949 우수마을

### DIFF
--- a/이지우/BJ_1949_우수마을.java
+++ b/이지우/BJ_1949_우수마을.java
@@ -1,0 +1,64 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BJ_1949_우수마을 {
+	static class Node{
+		int num;
+		Node next;
+		public Node(int num, Node next) {
+			this.num = num;
+			this.next = next;
+		}
+	}
+	static Node[] node;
+	static int[] popul;
+	static int[][] dp;
+	static boolean[] visited;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		node = new Node[N+1];
+		popul = new int[N+1];
+		dp = new int[N+1][2];
+		for(int i =1; i <=N; i++) {
+			popul[i] = Integer.parseInt(st.nextToken());
+		}
+		for(int i = 1; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			insert(from, to);
+			insert(to, from);
+		}
+		visited = new boolean[N+1];
+		dfs(1);
+		System.out.println(Math.max(dp[1][0], dp[1][1]));
+	}
+	private static void insert(int from, int to) {
+		if(node[from] == null)
+			node[from] = new Node(to, null);
+		else
+			node[from] = new Node(to, node[from]);
+	}
+	private static void dfs(int now) {
+		visited[now] = true;
+		dp[now][1] = popul[now];
+		Node next = node[now];
+		while(next != null) {
+			if(visited[next.num]) {
+				next = next.next;
+				continue;
+			}
+			dfs(next.num);
+			dp[now][1] += dp[next.num][0];
+			dp[now][0] += Math.max(dp[next.num][0], dp[next.num][1]);
+			next = next.next;
+		}
+	}
+}


### PR DESCRIPTION
인접리스트와 DP를 활용한 문제입니다.

- 문제 요점
```
트리 형태의 문제이므로 N개의 노드의 연결 간선은 N-1입니다. 인접행렬로 하게되면 메모리 초과가 발생할 수 있습니다.

이전단계의 부모 노드가 선택된 경우 그다음 자식 노드를 선택할 수 없고
부모 노드가 선택이 되지 않은경우는 자식노드를 선택하거나 안할 수 있습니다.
선택을 안해도 되는 이유는 최대 값을 구할경우 선택하는 쪽이 유리하므로 결국 최대한 선택하는 쪽으로 자동으로 처리가 됩니다. 
```

- 해결 방법
```
노드 배열을 만들고
해당 인덱스 노드가 null이면 자식이 없다고 판단 첫 자식을 넣어주고
자식노드가 있다면 자식노드를 포함한 노드를 새로 생성해 첫쨰자식으로 넣어줍니다.
이런식으로 데이터를 쌓아 놓은 뒤

시작 노드를 지정합니다. 이것이 루트 노드가 되는것이고
dp[x][0] -> 인덱스가 x인 노드를 선택 안했을때의 최대값
dp[x][1] -> 인덱스가 x인 노드를 선택 했을때의 최대값
을 쌓아 나갑니다.

그리하여 최종적으로는 루트노드가 1이라면 dp[1][0] dp[1][1] 중 큰값이 답이 되겠습니다.
```