### PR TITLE
✅ success: boj 2637 장남감 조립

### DIFF
--- a/이지우/BJ_2637_장남감조립.java
+++ b/이지우/BJ_2637_장남감조립.java
@@ -1,0 +1,75 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_2637_장남감조립 {
+	static int[] remain_need;
+	static int[][] graph;
+	static int[][] dp;
+	static int N;
+	static Queue<Integer> que = new LinkedList<>();
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		N = Integer.parseInt(br.readLine());
+		remain_need = new int[N+1];
+		graph = new int[N+1][N+1];
+		dp = new int[N+1][N+1];
+		int M = Integer.parseInt(br.readLine());
+		StringTokenizer st = null;
+		while(M-->0) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			remain_need[a]++;
+			graph[a][b] = c;
+		}
+		initToy();
+		makeToy();
+		for(int i = 1; i <= N; i++) {
+			if(dp[N][i] != 0) {
+				sb.append(i + " " + dp[N][i] + "\n");
+			}
+		}
+		System.out.println(sb.toString());
+	}
+	private static void initToy() {
+		for(int i = 1; i <= N; i++) {
+			if(remain_need[i] == 0) {
+				remain_need[i]--;
+				dp[i][i] = 1;
+				que.add(i);
+			}
+		}
+	}
+	private static void makeToy() {
+		while(!que.isEmpty()) {
+			int now = que.poll();
+			for(int i = 1; i <= N; i++) {
+				if(graph[i][now] != 0) {
+					remain_need[i]--;
+					for(int j = 1; j <=N; j++) {
+						dp[i][j] += (dp[now][j] * graph[i][now]);
+					}
+				}
+			}
+			findCanMake();
+		}
+		
+	}
+	private static void findCanMake() {
+		for(int i = 1; i <= N; i++) {
+			if(remain_need[i] == 0) {
+				remain_need[i]--;
+				que.add(i);
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
다이나믹 프로그래밍, 위상정렬, 그래프 이론을 활용한 문제입니다.

처음에 조립이 가능한지를 확인할 배열(remain_need)을 채웁니다.
간선이 있다면 조립이 불가능한 것입니다.
처음 세팅을 해주고 간선이 없는 기본부품을 차장 que에 넣어줍니다.
해당 간선으로 연결된 노드의 remain_need를 하나씩 제거하며 
간선이 모두 지워진것은 차례로 큐에 넣어줍니다.

이때 dp를 쌓아가며 진행해야하는데 그래프의 가중치를 필요부품의 배열에 곱해서 채워주면 됩니다.
골드 2치고는 쉬웠습니다.