### PR TITLE
✅ success: boj 4195 친구네트워크

### DIFF
--- a/이지우/BJ_4195_친구네트워크.java
+++ b/이지우/BJ_4195_친구네트워크.java
@@ -1,0 +1,69 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class BJ_4195_친구네트워크 {
+	static BufferedReader br;
+	static StringBuilder sb;
+	static StringTokenizer st;
+	static Map<String,Integer> users;
+	static int userNum;
+	static int[] parents;
+	static int[] level;
+	public static void main(String[] args) throws Exception {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		sb = new StringBuilder();
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int T = Integer.parseInt(br.readLine());
+		while(T-->0) {
+			mainSolution(Integer.parseInt(br.readLine()));
+		}
+		bw.write(sb.toString());
+		bw.flush();
+	}
+	private static void mainSolution(int M) throws Exception {
+		users = new HashMap<>();
+		userNum = 0;
+		parents = new int[M*2];
+		level = new int[M*2];
+		for(int i = 0; i < M*2; i++) {
+			parents[i] = i;
+			level[i] = 1;
+		}
+		while(M-->0) {
+			st = new StringTokenizer(br.readLine());
+			String userA = st.nextToken();
+			String userB = st.nextToken();
+			if(!users.containsKey(userA)) {
+				users.put(userA, userNum++);
+			}
+			if(!users.containsKey(userB)) {
+				users.put(userB, userNum++);
+			}
+			int aNum = users.get(userA);
+			int bNum = users.get(userB);
+			
+			sb.append(union(aNum, bNum) + "\n");
+		}
+		
+	}
+	private static int union(int aNum, int bNum) {
+		int a = find(aNum);
+		int b = find(bNum);
+		if(a == b)return level[a];
+		parents[a] = b;
+		level[b] += level[a];
+		return level[b];
+	}
+	private static int find(int a) {
+		if(parents[a] == a)return a;
+		return parents[a] = find(parents[a]);
+	}
+	
+}


### PR DESCRIPTION
저는 이문제를 보고 union find를 바로 떠올리지 못했는데

저는 union find 알고리즘이 기본적으로 여러개의 트리구조라고 생각해서
문제에서 주어진 규칙으로 설계하게 되면 순환이 이러나 트리구조가 아니라고 생각했습니다.

하지만 순한되지 않도록 루트 노드를 지정해주면 해결될 문제 였습니다.

처음에 map구조로 id를 받아 없는 경우는 고유값을 +1 하면서 유저를 생성시킨 뒤

매번 union find를 해서 루트노트의 레벨의 구해주면 해결되는 문제였습니다.