### PR TITLE
✅success: boj 10775 공항

### DIFF
--- a/이지우/BJ_10775_공항.java
+++ b/이지우/BJ_10775_공항.java
@@ -1,0 +1,39 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class BJ_10775_공항 {
+	static int [] parents;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int G = Integer.parseInt(br.readLine());
+		int T = Integer.parseInt(br.readLine());
+		parents = new int[G+1];
+		for(int i = 1 ; i <= G; i++) {
+			parents[i] = i;
+		}
+		int ans = 0;
+		while(T-->0) {
+			int x = Integer.parseInt(br.readLine());
+			int parent = find(x);
+			if(parent == 0)break;
+			ans++;
+			union(parent, parent-1);
+		}
+		System.out.println(ans);
+	}
+	private static void union(int x, int y) {
+		int xx = find(x);
+		int yy = find(y);
+		
+		if(xx != yy) {
+			parents[xx] = yy;
+		}
+	}
+	private static int find(int x) {
+		if(parents[x] == x)return x;
+		return parents[x] = find(parents[x]);
+	}
+
+}


### PR DESCRIPTION
유니오 파인드 문제였습니다.

간단한 문제 설명을 하자면 값이 주어지면  그보다 작거나 같은 칸이 비어있으면 들어갈 수 있는 최대이고
만약에 중간에 못들어가는 경우가 있다면 그 즉시 멈춰야 합니다.

parents배열에 각 인덱스를 해당 값으로 초기화하고

단계가 넘어갈때마다 해당 i의 parents값을 찾아온 값을 x라고 했을때 x와 x-1을 union 시켜주면서 넘어가면 결국 0으로 수렴하게 되는데 이때 0으로 수렴되는 순간 공항이 폐쇄 됩니다.