### PR TITLE
✅success: boj 12920 평범한 배낭2

### DIFF
--- a/이지우/BJ_12920_평범한배낭2.java
+++ b/이지우/BJ_12920_평범한배낭2.java
@@ -1,0 +1,52 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BJ_12920_평범한배낭2 {
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int[] max_val = new int[M+1];
+		ArrayList<int[]> arr = new ArrayList<>();
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int dist = Integer.valueOf(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			int num = Integer.parseInt(st.nextToken());
+		
+			for(int j = 0; num > 0; j++) {
+				int tmp = 1<<j;
+				tmp = Math.min(tmp, num);
+				arr.add(new int[] {dist*tmp, w*tmp});
+				num-=tmp;
+			}
+		}
+		
+		for(int[] stuff : arr) {
+			for(int j = M; j >= stuff[0]; j--) {
+				max_val[j] = Math.max(max_val[j - stuff[0]] + stuff[1] , max_val[j]);
+			}		
+		}
+		
+		System.out.println(max_val[M]);
+	}
+	
+}
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
플레 4라서 긴장을 하고 풀었는데

문제를 읽고 그냥 배낭문제랑 다를게 없다고 생각해서 왜이리 쉽나하고 제출했는데 역시 틀렸습니다.

시간초과를 피하려면 그룹을 지어서 물건들을 처리해야하는데 예를들어

연필이 15개 있다고 하면 연필 15개를 모두 넣는게 아니라

2의 제곱으로 묶어서 넣어준다고 생각하면 됩니다.

1, 2, 4, 8로 묶어서 넣어주게 되면 15개 돌게 4번만 돌면 됩니다.

이때 중요한점은 1~15에 안의 수가  묶은 그룹의 조합으로 모두 만들어 질 수 있어야한다는겁니다.

11 같은경우는

1,2,4,4 가 필요한데 이를 어떻게 로직으로 처리하느냐가 관건인 문제 였습니다.

힌트는 제곱으로 빼고 남은 값을 넣어주면 됩니다. 