### PR TITLE
✅ success: boj 1167 트리의지름

### DIFF
--- a/이지우/BJ_1167_트리의지름.java
+++ b/이지우/BJ_1167_트리의지름.java
@@ -1,0 +1,92 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BJ_1167_트리의지름 {
+	static class Node{
+		Node node;
+		int w;
+		int num;
+		Node(Node node, int w, int num){
+			this.node = node;
+			this.w = w;
+			this.num = num;
+		}
+	}
+	static Node[] nList;
+	static boolean[] visited;
+	static int max;
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N  = Integer.valueOf(br.readLine());
+		nList = new Node[N+1];
+		visited = new boolean[N+1];
+		StringTokenizer st = null;
+		while(N-->0) {
+			st = new StringTokenizer(br.readLine());
+			int index = Integer.valueOf(st.nextToken());
+			int num = 0;
+			int weight = 0;
+			do{
+				num = Integer.valueOf(st.nextToken());
+				if(num > 0) {
+					weight = Integer.valueOf(st.nextToken());
+					nList[index] = new Node(nList[index], weight, num);
+				}
+			}while(st.hasMoreElements());
+		}
+		dfs(1);
+		System.out.println(max);
+	}
+	private static int dfs(int index) {
+		int one = 0;
+		int two = 0;
+		visited[index] = true;
+		
+		for(Node n = nList[index]; n != null; n = n.node) {
+			if(visited[n.num])continue;
+			int tmp = dfs(n.num) + n.w;
+			if(tmp > one) {
+				two = one;
+				one = tmp;
+			}else if(tmp > two) {
+				two = tmp;
+			}
+		}
+		max = Math.max(max, one+two);
+		
+		return one;
+	}	
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
골드 2문제로 쉽진 않았는데 생각을 조금 하면 어렵지 않은 문제였습니다.
말그대로 트리이기때문에 간선은 N-1일것이며 순환이 일어나지 않을것임을 생각하고 풀면 쉽습니다.

1. 연결리스트를 생성합니다.
2. 어느 점이든 dfs를 시작합니다
3. 한 작업의 단위에서 최고값과 두번째 최곳값을 구해 max를 최신화 해줍니다. 그리도 호출한 상위 작업에 최곳값만 넒겨줍니다 <br>   그이유는 한노드에서의 두점의 가장 긴거리는 하위 노드 중 첫번째와 두번째로 큰 거리의 합일것입니다.
<br>   하지만 상위 노드 입장에선 두개의 값을 다 취할 수 없어 가장 큰값이 가장 유리한 값이 됩니다.
4. max를 출력하면 됩니다.