### PR TITLE
✅ success: boj 2252 줄세우기

### DIFF
--- a/이지우/BJ_2252_줄세우기.java
+++ b/이지우/BJ_2252_줄세우기.java
@@ -1,0 +1,47 @@
+package A202207;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BJ_2252_줄세우기 {
+	static Node[] list;
+	static StringBuilder sb;
+	static boolean[] visited;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		sb = new StringBuilder();
+		int N = Integer.valueOf(st.nextToken());
+		int M = Integer.valueOf(st.nextToken());
+		list = new Node[N+1];
+		visited = new boolean[N+1];
+		while(M-->0) {
+			st = new StringTokenizer(br.readLine());
+			int s = Integer.valueOf(st.nextToken());
+			int t = Integer.valueOf(st.nextToken());
+			list[t] = new Node(s,list[t]);
+		}
+		for(int i = 1; i <= N; i++) {
+			if(visited[i])continue;
+			dfs(i);
+		}
+		System.out.println(sb.toString());
+	}
+	private static void dfs(int n) {
+		visited[n] = true;
+		for(Node node = list[n]; node != null; node = node.next) {
+			if(!visited[node.num])dfs(node.num);
+		}
+		sb.append(n+" ");
+	}
+}
+class Node{
+	int num;
+	Node next;
+	public Node(int num, Node next) {
+		this.num = num;
+		this.next = next;
+	}
+}


### PR DESCRIPTION
문제에서 의도한건 위상정렬으로 fan_in 이 0 인거부터 큐에 넣고 돌리는 식입니다.
그니까 리프 노드부터 순차적으로 올라오는 방법인데

저는 이걸 생각못해서 그냥 위에서 부터 dfs를 돌렸습니다.
그래서 자식이 없으면 순차적으로 답에 넣어서 해결했습니다.

효율성은 비슷한거 같습니다.
노드 개수가 많기 때문에 인접행렬이 아닌 인접리스트로 해결해야합니다.
