### PR TITLE
✅ success: boj 2225 합분해

### DIFF
--- a/이지우/BJ_2225_합분해.java
+++ b/이지우/BJ_2225_합분해.java
@@ -1,0 +1,47 @@
+package A202208;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BJ_2225_합분해 {
+	static final int mod = 10_0000_0000;
+	static int N, K;
+	static long[][] dp;
+	static long ans = 0;
+	public static void main(String[] args)  throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		setDp();
+		System.out.println(dp[K][N]);
+	}
+	private static void setDp() {
+		dp = new long[K+1][N+1];
+		for(int i = 1; i <=K; i++) {
+			dp[i][0] = 1; 
+			for(int j = 1; j <= N; j++) {
+				dp[i][j] = dp[i][j-1]+dp[i-1][j]%mod;
+			}
+		}
+		
+	}
+	
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
결국 dp문제입니다. 규칙을 찾아야하는데 중요한점은 중복가능하고 0을 포함할 수 있다는 것입니다.

k : 선택한 숫자 개수
n : 목표 합

dp[2][3] : 2개를 선택해서 목표 합이 나올 수 있는 개수
dp[2][3] = dp[1][0] + dp[1][1] + dp[1][2] + dp[1][3]  // 4     이부분을 이해해야합니다. 설명이 길어지므로 생략하겠습니다.
dp[2][4] = dp[1][0] + dp[1][1] + dp[1][2] + dp[1][3] + dp[1][4]  // 5
dp[2][4] = dp[2][3] + dp[1][4] 가 성립합니다.

즉 dp[k][n] = dp[k][n-1] + dp[k-1][n]

이 점을 활용해서 문제를 해결하시면 됩니다.
