### PR TITLE
✅ success: boj 9465 스티커

### DIFF
--- a/이지우/BJ_9465_스티커.java
+++ b/이지우/BJ_9465_스티커.java
@@ -1,0 +1,40 @@
+package A202209;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BJ_9465_스티커 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int T = Integer.parseInt(br.readLine());
+		while(T-->0) {
+			int N = Integer.parseInt(br.readLine());
+			int[] up = new int[N];
+			int[] down = new int[N];
+			int[][] dp = new int[2][N];
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int i = 0; i < N; i++)up[i]=Integer.parseInt(st.nextToken());
+			st = new StringTokenizer(br.readLine());
+			for(int i = 0; i < N; i++)down[i]=Integer.parseInt(st.nextToken());
+			dp[0][0] = up[0];
+			dp[1][0] = down[0];
+			if(N==1) {
+				sb.append(Math.max(dp[0][0], dp[1][0])).append("\n");
+				continue;
+			}
+			dp[0][1] = dp[1][0] + up[1];
+			dp[1][1] = dp[0][0] + down[1];
+			for(int i = 2; i < N; i++) {
+				dp[0][i] = Math.max(dp[1][i-1], dp[1][i-2]) + up[i];
+				dp[1][i] = Math.max(dp[0][i-1], dp[0][i-2]) + down[i];
+			}
+			sb.append(Math.max(dp[1][N-1], dp[0][N-1])).append("\n");
+		}
+		System.out.println(sb);
+	}
+
+}


### PR DESCRIPTION
dp문제입니다.

첫번째랑 두번쨰까지는 직접 채우고 세번쨰부터 끝까지는 아래 점화식으로 쌓아서 풀면 됩니다.

위 와 아래 로 나누어 dp를 쌓을떄

dp[위][N] = MAX(dp[아래][N-1], dp[아래][N-2]) + value[N];

인것을 알 수 있습니다.

전단계에서 같은 위치는 못오기때문에 반대 위치 하나만 올 수 있고
전전단계에서는 둘 다 올 수 있지만 들어오는 값은 0을 포함한 양의 정수이기 때문에 
전전단계의 같은 위치 값은 전단계의 반대 위치값보다 클 수 없어서 생략이 가능합니다.
전전전단계 부터 최초단계는 모두 전전단계와 전단계에 포함되기 떄문에 생략이 가능합니다.