### PR TITLE
✅ success: boj 9252 LCS2

### DIFF
--- a/이지우/BJ_9252_LCS2.java
+++ b/이지우/BJ_9252_LCS2.java
@@ -1,0 +1,35 @@
+package A202209;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class BJ_9252_LCS2 {
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		char[] arrA = br.readLine().toCharArray();
+		char[] arrB = br.readLine().toCharArray();
+		int N = arrA.length;
+		int M = arrB.length;
+		int[][] dp = new int[M+1][N+1];
+		for(int i = 1; i <= M; i++) {
+			for(int j = 1; j <= N; j++) {
+				if(arrA[j-1] == arrB[i-1])dp[i][j] = dp[i-1][j-1]+1;
+				else dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]);
+			}
+		}
+		int i = M;
+		int j = N;
+		while(i>0 && j>0) {
+			if(dp[i][j] == dp[i-1][j])i--;
+			else if(dp[i][j] == dp[i][j-1])j--;
+			else {
+				sb.append(arrA[j-1]);
+				i--;j--;
+			}
+		}
+		System.out.println(sb.length());
+		if(sb.length()>0)System.out.println(sb.reverse());
+	}
+}


### PR DESCRIPTION
최장 공통 수열 문제입니다.

최대값을 구하는것은 간단합니다.
dp를 쌓는 것인데
문자열을 비교해 같으면 전단계의 전인덱스의 값 +1을 하면되고
                            다르면 전단계의 같은 인덱스 와 현단계의 전인덱스를 비교해 큰쪽을 넣어서 쌓아가면 됩니다.
이렇게 되면 dp[N][M]에는 최장길이 값이 쌓이게 됩니다.

하지만 이문제에서는 최장길이뿐 아니라 최장길이가 어떤 문자열로 구성되었는지를 보여야합니다.
그래서 쌓은 dp를 꺼꾸러 읽을 필요가 생깁니다.
역순으로 진행하기 때문에 값이 위랑같다면 위로가고 왼쪽과 같다면 왼쪽으로 갑니다.
둘다 같지 않다면 여기서 수열을 쌓은것이라고 생각할 수 있습니다. 해당값을 문자열에 추가합니다.
그다음에는 대각선 왼쪽위로 이동해야합니다. 왜냐면 현단계의 인덱스를 이미 써버렸기때문에 더이상 비교할수 없는 위치가 됩니다.
이런식으로 구해서 답을 제출하면 됩니다.

의문점이 생기는데 다음단계에서 더 효율적으로 쌓은 dp값이 생겼는데 최종적으로는 최장값을 갱신하지 못해 dp가 꼬이지 않을까 생각을 해봤는데

역순으로 조회하면 위와 같으면 올라가는 단계에서 다 제거 됩니다.